### PR TITLE
Fix function declaration without a prototype

### DIFF
--- a/noeol.c
+++ b/noeol.c
@@ -6,7 +6,7 @@ char buf[512];
 bool haveeol = false;
 size_t n;
 
-int main() {
+int main(void) {
     while((n = read(0, buf, sizeof(buf)))) {
         if (haveeol) { putchar('\n'); }
         if (buf[n-1] == '\n') {


### PR DESCRIPTION
Running `make` on any modern C compiler produces this error:

```sh
cc -Wall -Wpedantic -Werror -O3    noeol.c   -o noeol
noeol.c:9:9: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
int main() {
        ^
         void
1 error generated.
make: *** [noeol] Error 1
```